### PR TITLE
Use `setMaxListeners` based on pool's max queue size

### DIFF
--- a/middleware/pool/promise-pool.js
+++ b/middleware/pool/promise-pool.js
@@ -3,6 +3,7 @@ const EventEmitter = require('events');
 class PromisePool extends EventEmitter {
   constructor(concurrency=10, maxQueued=30) {
     super();
+    this.setMaxListeners(maxQueued * 2);
     this._concurrent = concurrency;
     this._maxQueued = maxQueued;
     this._queued = 0;

--- a/test.js
+++ b/test.js
@@ -64,6 +64,7 @@ test.afterEach(() => wsClientMock.send = null);
 
 test('[Unit] PromisePool test', async t => {
   const pool = new PromisePool(2, 2);
+  t.is(pool.getMaxListeners(), 4);
   const factory = n => pool.wrap(() => sleep(n * 40));
   const a = pool.run(() => Promise.reject(5));
   const [b, c, d, e] = Array.from({ length: 4 }).map((_, i) =>


### PR DESCRIPTION
- [x] ready for merge
- [x] tests reviewed
- [x] code review by @joshje
#### What's this PR do?

Gets rid of un-needed emitter warnings due to high number of listeners for the pool's `done` event.
#### Where should the reviewer start?
#### How should this be manually tested?
#### Any background context you want to provide?
#### What are the relevant tickets?
#### Screenshots
#### Release Notes?
#### Questions
